### PR TITLE
Add Search Functionality to Fetch News Based on User Query

### DIFF
--- a/src/Components/News/News.tsx
+++ b/src/Components/News/News.tsx
@@ -1,15 +1,12 @@
 /** @format */
 
-import type { RootState } from '../../Redux/store';
 import { NewsHeadline, NewsBox } from '../index';
-import { useSelector } from 'react-redux';
 
 const News = () => {
-  const { category } = useSelector((state: RootState) => state.news);
   return (
     <section className='w-[70%] h-[calc(100vh-40px)] flex flex-col gap-2'>
-      <NewsHeadline category={category} />
-      <NewsBox category={category} />
+      <NewsHeadline />
+      <NewsBox />
     </section>
   );
 };

--- a/src/Components/News/NewsBox.tsx
+++ b/src/Components/News/NewsBox.tsx
@@ -4,8 +4,8 @@ import { useNewsData } from '../../Hooks/useNewsData';
 import NewsCard from './NewsCard';
 import NewsError from './NewsError';
 
-const NewsBox = ({ category }: { category: string }) => {
-  const { isLoading, data: newsData, error } = useNewsData(category);
+const NewsBox = () => {
+  const { isLoading, data: newsData, error } = useNewsData();
 
   if (error) return <NewsError />;
 

--- a/src/Components/News/NewsHeadline.tsx
+++ b/src/Components/News/NewsHeadline.tsx
@@ -4,8 +4,8 @@ import { useNewsData } from '../../Hooks/useNewsData';
 import NewsError from './NewsError';
 import { openInNewsTab } from '../../utils/openInNewsTab';
 
-const NewsHeadline = ({ category }: { category: string }) => {
-  const { data, error, isLoading } = useNewsData(category);
+const NewsHeadline = () => {
+  const { data, error, isLoading } = useNewsData();
   if (!data?.articles?.length) return null;
   const newsHeadline = data?.articles[0];
 

--- a/src/Components/Sidebar/Categories.tsx
+++ b/src/Components/Sidebar/Categories.tsx
@@ -5,7 +5,7 @@ import { newsCategories } from '../../Constants/Categories';
 import { useNewsData } from '../../Hooks/useNewsData';
 
 const Categories = () => {
-  const { handleCategoryClick } = useNewsData(null);
+  const { handleCategoryClick } = useNewsData();
 
   return (
     <nav className='w-full h-[55%] bg-[#111214] rounded-md flex flex-col px-4 py-5 overflow-hidden'>

--- a/src/Hooks/useNewsData.ts
+++ b/src/Hooks/useNewsData.ts
@@ -1,15 +1,46 @@
 /** @format */
 
-import { useDispatch } from 'react-redux';
-import { useFetchNewsArticlesQuery } from '../Redux/Slices/News/newsApi';
-import { setCategory } from '../Redux/Slices/News/newsSlice';
+// /** @format */
 
-export const useNewsData = (category: string | null) => {
-  const { data, error, isLoading } = useFetchNewsArticlesQuery(category);
+// import { useDispatch } from 'react-redux';
+// import { useFetchNewsArticlesQuery } from '../Redux/Slices/News/newsApi';
+// import { setCategory, setSearch } from '../Redux/Slices/News/newsSlice';
+
+// export const useNewsData = (category?: string | null, search?: string | null) => {
+//   const { data, error, isLoading } = useFetchNewsArticlesQuery({ category, search });
+//   const dispatch = useDispatch();
+
+//   const handleCategoryClick = (newsCategory: string) => {
+//     return dispatch(setCategory(newsCategory.toLowerCase()));
+//   };
+
+//   const handleSearchSubmit = (query: string) => {
+//     return dispatch(setSearch(query.trim()));
+//   };
+
+//   return { data, error, isLoading, handleCategoryClick, handleSearchSubmit };
+// };
+
+/** @format */
+import { useSelector, useDispatch } from 'react-redux';
+import { useFetchNewsArticlesQuery } from '../Redux/Slices/News/newsApi';
+import { setCategory, setSearch } from '../Redux/Slices/News/newsSlice';
+import type { RootState } from '../Redux/store';
+
+export const useNewsData = () => {
   const dispatch = useDispatch();
+  const { category, search } = useSelector((state: RootState) => state.news);
+
+  const { data, error, isLoading } = useFetchNewsArticlesQuery({ category, search });
 
   const handleCategoryClick = (newsCategory: string) => {
-    return dispatch(setCategory(newsCategory.toLowerCase()));
+    dispatch(setCategory(newsCategory.toLowerCase()));
+    dispatch(setSearch('')); // optional: clear search when category is clicked
   };
-  return { data, error, isLoading, handleCategoryClick };
+
+  const handleSearchSubmit = (query: string) => {
+    dispatch(setSearch(query.trim()));
+  };
+
+  return { data, error, isLoading, handleCategoryClick, handleSearchSubmit };
 };

--- a/src/Redux/Slices/News/newsApi.ts
+++ b/src/Redux/Slices/News/newsApi.ts
@@ -14,8 +14,20 @@ export const newsApi = createApi({
   }),
 
   endpoints: (builder) => ({
-    fetchNewsArticles: builder.query<NewsApiResponse, string | null>({
-      query: (category) => `top-headlines?category=${category}&lang=en&apikey=${API_KEY}`,
+    fetchNewsArticles: builder.query<NewsApiResponse, { category?: string | null; search?: string | null }>({
+      query: ({ category, search }) => {
+        if (search) {
+          return {
+            url: `/search?q=${search}&lang=en&apikey=${API_KEY}`,
+            method: 'GET',
+          };
+        }
+
+        return {
+          url: `/top-headlines?category=${category || 'general'}&lang=en&apikey=${API_KEY}`,
+          method: 'GET',
+        };
+      },
     }),
   }),
 });

--- a/src/Redux/Slices/News/newsSlice.ts
+++ b/src/Redux/Slices/News/newsSlice.ts
@@ -5,6 +5,7 @@ import type { NewsCategory } from './types';
 
 const initialState: NewsCategory = {
   category: 'genral',
+  search: '',
 };
 
 const newsSlice = createSlice({
@@ -15,8 +16,11 @@ const newsSlice = createSlice({
     setCategory: (state, action: PayloadAction<string>) => {
       state.category = action.payload;
     },
+    setSearch: (state, action: PayloadAction<string>) => {
+      state.search = action.payload;
+    },
   },
 });
 
-export const { setCategory } = newsSlice.actions;
+export const { setCategory, setSearch } = newsSlice.actions;
 export const newsReducer = newsSlice.reducer;

--- a/src/Redux/Slices/News/types.ts
+++ b/src/Redux/Slices/News/types.ts
@@ -1,7 +1,8 @@
 /** @format */
 
 export interface NewsCategory {
-  category: string;
+  category: string | null;
+  search: string | null;
 }
 interface NewsSource {
   name: string;

--- a/src/UI/SearchBar.tsx
+++ b/src/UI/SearchBar.tsx
@@ -1,19 +1,33 @@
 /** @format */
 
 import { FaSearch } from 'react-icons/fa';
+import { useRef } from 'react';
+import { useNewsData } from '../Hooks/useNewsData';
 
 const SearchBar = () => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const { handleSearchSubmit } = useNewsData();
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const query = inputRef.current?.value.trim();
+    if (query) {
+      return handleSearchSubmit(query);
+    }
+  };
+
   return (
-    <form className='relative'>
+    <form className='relative' onSubmit={handleSubmit}>
       <div>
         <input
+          ref={inputRef}
           type='text'
           className='border border-black bg-[#111214] px-4 py-2 rounded-full w-md outline-gray-800'
           placeholder='Search News'
         />
-        <div>
-          <FaSearch className='absolute right-4 top-3 text-gray-400' />
-        </div>
+        <button type='submit'>
+          <FaSearch className='absolute right-4 top-3 text-gray-400 cursor-pointer' />
+        </button>
       </div>
     </form>
   );


### PR DESCRIPTION
### 🔍 Summary
This PR introduces the ability to search news articles by keyword in addition to category-based filtering.

### ✅ Changes
- Integrated search input with Redux state (`search`)
- Updated `useNewsData` hook to use `useSelector` for dynamic `category` and `search` tracking
- Modified API logic in `newsApi` to switch between `/top-headlines` and `/search` endpoints
- Hook now handles both category and search updates in a clean, unified way


