### PR TITLE
Enable deleting individual bookmarks from the modal

### DIFF
--- a/src/Components/News/NewsBookMark.tsx
+++ b/src/Components/News/NewsBookMark.tsx
@@ -1,0 +1,37 @@
+/** @format */
+
+import { useSelector } from 'react-redux';
+import type { RootState } from '../../Redux/store';
+import { useNewsData } from '../../Hooks/useNewsData';
+
+const NewsBookMark = () => {
+  const { bookmark } = useSelector((state: RootState) => state.news);
+  const { handleToggleBookmark } = useNewsData();
+  return (
+    <div className='fixed inset-0 backdrop-blur-sm flex items-center justify-center z-50'>
+      <div className='bg-[#1b1d21] text-white w-[90%] sm:w-[70%] md:w-[50%] lg:w-[50%] xl:w-[40%] h-[70%] p-6 rounded-2xl shadow-lg overflow-y-auto relative flex flex-col items-start gap-4'>
+        <div className='flex justify-between w-full'>
+          <h2 className='text-3xl'>BOOKMARKED NEWS</h2>
+          <button onClick={handleToggleBookmark}>❌</button>
+        </div>
+        {bookmark?.map((news, index) => (
+          <div
+            key={index}
+            className='flex items-center gap-4 w-full bg-[#2a2c30] rounded-lg p-4 shadow-md hover:bg-[#3a3c40] transition-colors duration-200'>
+            <img src={news.image} alt={news.title} className='w-28 h-20 object-cover rounded-md shadow-sm shrink-0' />
+
+            <div className='flex justify-between items-center w-full'>
+              <p className='text-sm text-gray-200 line-clamp-3 pr-4'>{news.description}</p>
+
+              <button className='w-8 h-8 flex items-center justify-center text-xs transition' title='Remove'>
+                ❌
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default NewsBookMark;

--- a/src/Components/News/NewsBookMark.tsx
+++ b/src/Components/News/NewsBookMark.tsx
@@ -6,7 +6,7 @@ import { useNewsData } from '../../Hooks/useNewsData';
 
 const NewsBookMark = () => {
   const { bookmark } = useSelector((state: RootState) => state.news);
-  const { handleToggleBookmark } = useNewsData();
+  const { handleToggleBookmark, handleDeleteBookMark } = useNewsData();
   return (
     <div className='fixed inset-0 backdrop-blur-sm flex items-center justify-center z-50'>
       <div className='bg-[#1b1d21] text-white w-[90%] sm:w-[70%] md:w-[50%] lg:w-[50%] xl:w-[40%] h-[70%] p-6 rounded-2xl shadow-lg overflow-y-auto relative flex flex-col items-start gap-4'>
@@ -23,7 +23,10 @@ const NewsBookMark = () => {
             <div className='flex justify-between items-center w-full'>
               <p className='text-sm text-gray-200 line-clamp-3 pr-4'>{news.description}</p>
 
-              <button className='w-8 h-8 flex items-center justify-center text-xs transition' title='Remove'>
+              <button
+                className='w-8 h-8 flex items-center justify-center text-xs transition'
+                title='Remove'
+                onClick={() => handleDeleteBookMark(index)}>
                 ❌
               </button>
             </div>

--- a/src/Components/News/NewsCard.tsx
+++ b/src/Components/News/NewsCard.tsx
@@ -1,19 +1,16 @@
 /** @format */
 
 import { FaBookmark } from 'react-icons/fa';
-import type { NewsArticle } from '../../Redux/Slices/News/types';
 import NewsModalBox from './NewsModalBox';
 import { useSelector } from 'react-redux';
 import type { RootState } from '../../Redux/store';
 import { useNewsData } from '../../Hooks/useNewsData';
-interface NewsCardProps {
-  news: NewsArticle;
-  index: number;
-}
+import type { NewsCardProps } from '../../Types/News';
+import NewsBookMark from './NewsBookMark';
 
 const NewsCard = ({ news, index }: NewsCardProps) => {
-  const modalIndex = useSelector((state: RootState) => state.news.modalIndex);
-  const { handleModalOpen, handleModalClose } = useNewsData();
+  const { modalIndex, isBookMarkOpen } = useSelector((state: RootState) => state.news);
+  const { handleModalOpen, handleModalClose, handleAddBookamrk } = useNewsData();
 
   return (
     <>
@@ -25,12 +22,16 @@ const NewsCard = ({ news, index }: NewsCardProps) => {
           <h3 className='text-lg text-white font-semibold line-clamp-2'>{news.title}</h3>
           <div className='flex justify-between items-center mt-2'>
             <p className='text-sm text-gray-400'>{new Date(news.publishedAt).toLocaleDateString()}</p>
-            <FaBookmark className='text-white cursor-pointer hover:text-yellow-400 transition-colors' />
+            <FaBookmark
+              className='text-white cursor-pointer hover:text-yellow-400 transition-colors'
+              onClick={() => handleAddBookamrk(news)}
+            />
           </div>
         </div>
       </div>
 
       {modalIndex === index && <NewsModalBox onClose={handleModalClose} news={news} />}
+      {isBookMarkOpen && <NewsBookMark />}
     </>
   );
 };

--- a/src/Components/News/NewsModalBox.tsx
+++ b/src/Components/News/NewsModalBox.tsx
@@ -1,13 +1,8 @@
 /** @format */
 
-import type { NewsArticle } from '../../Redux/Slices/News/types';
 import { formatNewsDate } from '../../utils/formatNewDate';
 import { openInNewsTab } from '../../utils/openInNewsTab';
-
-interface NewsModalBoxProps {
-  onClose: () => void;
-  news: NewsArticle;
-}
+import type { NewsModalBoxProps } from '../../Types/News';
 
 const NewsModalBox = ({ onClose, news }: NewsModalBoxProps) => {
   const iso = news.publishedAt;

--- a/src/Components/Sidebar/Categories.tsx
+++ b/src/Components/Sidebar/Categories.tsx
@@ -5,7 +5,7 @@ import { newsCategories } from '../../Constants/Categories';
 import { useNewsData } from '../../Hooks/useNewsData';
 
 const Categories = () => {
-  const { handleCategoryClick } = useNewsData();
+  const { handleCategoryClick, handleToggleBookmark } = useNewsData();
 
   return (
     <nav className='w-full h-[55%] bg-[#111214] rounded-md flex flex-col px-4 py-5 overflow-hidden'>
@@ -22,7 +22,9 @@ const Categories = () => {
             {category}
           </li>
         ))}
-        <li className='flex justify-center items-center w-full gap-4 p-2 hover:bg-[#22242a] rounded-md transition-colors border-t  border-zinc-400'>
+        <li
+          className='flex justify-center items-center w-full gap-4 p-2 hover:bg-[#22242a] rounded-md transition-colors border-t  border-zinc-400'
+          onClick={handleToggleBookmark}>
           Bookmark
           <span className=''>
             <FaBookmark />

--- a/src/Hooks/useNewsData.ts
+++ b/src/Hooks/useNewsData.ts
@@ -1,9 +1,10 @@
 /** @format */
 import { useSelector, useDispatch } from 'react-redux';
 import { useFetchNewsArticlesQuery } from '../Redux/Slices/News/newsApi';
-import { clearSearch, setCategory, setSearch } from '../Redux/Slices/News/newsSlice';
+import { addBookMark, clearSearch, setCategory, setSearch, toggleBookmarkModal } from '../Redux/Slices/News/newsSlice';
 import type { RootState } from '../Redux/store';
 import { toggleModal } from '../Redux/Slices/News/newsSlice';
+import type { NewsArticle } from '../Redux/Slices/News/types';
 
 export const useNewsData = () => {
   const dispatch = useDispatch();
@@ -28,5 +29,23 @@ export const useNewsData = () => {
     dispatch(toggleModal(null));
   };
 
-  return { data, error, isLoading, handleCategoryClick, handleSearchSubmit, handleModalOpen, handleModalClose };
+  const handleAddBookamrk = (news: NewsArticle) => {
+    dispatch(addBookMark(news));
+  };
+
+  const handleToggleBookmark = () => {
+    dispatch(toggleBookmarkModal());
+  };
+
+  return {
+    data,
+    error,
+    isLoading,
+    handleCategoryClick,
+    handleSearchSubmit,
+    handleModalOpen,
+    handleModalClose,
+    handleAddBookamrk,
+    handleToggleBookmark,
+  };
 };

--- a/src/Hooks/useNewsData.ts
+++ b/src/Hooks/useNewsData.ts
@@ -1,7 +1,14 @@
 /** @format */
 import { useSelector, useDispatch } from 'react-redux';
 import { useFetchNewsArticlesQuery } from '../Redux/Slices/News/newsApi';
-import { addBookMark, clearSearch, setCategory, setSearch, toggleBookmarkModal } from '../Redux/Slices/News/newsSlice';
+import {
+  addBookMark,
+  clearSearch,
+  deleteBookmark,
+  setCategory,
+  setSearch,
+  toggleBookmarkModal,
+} from '../Redux/Slices/News/newsSlice';
 import type { RootState } from '../Redux/store';
 import { toggleModal } from '../Redux/Slices/News/newsSlice';
 import type { NewsArticle } from '../Redux/Slices/News/types';
@@ -33,6 +40,10 @@ export const useNewsData = () => {
     dispatch(addBookMark(news));
   };
 
+  const handleDeleteBookMark = (index: number) => {
+    dispatch(deleteBookmark(index));
+  };
+
   const handleToggleBookmark = () => {
     dispatch(toggleBookmarkModal());
   };
@@ -47,5 +58,6 @@ export const useNewsData = () => {
     handleModalClose,
     handleAddBookamrk,
     handleToggleBookmark,
+    handleDeleteBookMark,
   };
 };

--- a/src/Redux/Slices/News/newsSlice.ts
+++ b/src/Redux/Slices/News/newsSlice.ts
@@ -1,12 +1,14 @@
 /** @format */
 
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
-import type { NewsCategory } from './types';
+import type { NewsCategory, NewsArticle } from './types';
 
 const initialState: NewsCategory = {
   category: 'genral',
   search: '',
   modalIndex: null,
+  bookmark: [],
+  isBookMarkOpen: false,
 };
 
 const newsSlice = createSlice({
@@ -14,20 +16,32 @@ const newsSlice = createSlice({
   initialState,
 
   reducers: {
+    // Set Selected News Category
     setCategory: (state, action: PayloadAction<string>) => {
       state.category = action.payload;
     },
+    // Search query entered by user
     setSearch: (state, action: PayloadAction<string>) => {
       state.search = action.payload;
     },
+    // Clear Search
     clearSearch: (state, action: PayloadAction<string | null>) => {
       state.search = action.payload;
     },
+    // Toggle the Modal
     toggleModal: (state, action: PayloadAction<number | null>) => {
       state.modalIndex = action.payload;
+    },
+    // Add BookMark
+    addBookMark: (state, action: PayloadAction<NewsArticle>) => {
+      state.bookmark?.push(action.payload);
+    },
+    // Toggle Bookmark Modal
+    toggleBookmarkModal: (state) => {
+      state.isBookMarkOpen = !state.isBookMarkOpen;
     },
   },
 });
 
-export const { setCategory, setSearch, clearSearch, toggleModal } = newsSlice.actions;
+export const { setCategory, setSearch, clearSearch, toggleModal, addBookMark, toggleBookmarkModal } = newsSlice.actions;
 export const newsReducer = newsSlice.reducer;

--- a/src/Redux/Slices/News/newsSlice.ts
+++ b/src/Redux/Slices/News/newsSlice.ts
@@ -9,6 +9,7 @@ const initialState: NewsCategory = {
   modalIndex: null,
   bookmark: [],
   isBookMarkOpen: false,
+  bookmarkIndex: null,
 };
 
 const newsSlice = createSlice({
@@ -36,6 +37,12 @@ const newsSlice = createSlice({
     addBookMark: (state, action: PayloadAction<NewsArticle>) => {
       state.bookmark?.push(action.payload);
     },
+    // Delete BookMark
+    deleteBookmark: (state, action: PayloadAction<number | null>) => {
+      if (state.bookmark) {
+        state.bookmark = state.bookmark.filter((_, i) => i !== action.payload);
+      }
+    },
     // Toggle Bookmark Modal
     toggleBookmarkModal: (state) => {
       state.isBookMarkOpen = !state.isBookMarkOpen;
@@ -43,5 +50,6 @@ const newsSlice = createSlice({
   },
 });
 
-export const { setCategory, setSearch, clearSearch, toggleModal, addBookMark, toggleBookmarkModal } = newsSlice.actions;
+export const { setCategory, setSearch, clearSearch, toggleModal, addBookMark, toggleBookmarkModal, deleteBookmark } =
+  newsSlice.actions;
 export const newsReducer = newsSlice.reducer;

--- a/src/Redux/Slices/News/types.ts
+++ b/src/Redux/Slices/News/types.ts
@@ -6,6 +6,7 @@ export interface NewsCategory {
   modalIndex: number | null;
   bookmark: NewsArticle[] | null;
   isBookMarkOpen: boolean;
+  bookmarkIndex: number | null;
 }
 interface NewsSource {
   name: string;

--- a/src/Redux/Slices/News/types.ts
+++ b/src/Redux/Slices/News/types.ts
@@ -4,6 +4,8 @@ export interface NewsCategory {
   category: string | null;
   search: string | null;
   modalIndex: number | null;
+  bookmark: NewsArticle[] | null;
+  isBookMarkOpen: boolean;
 }
 interface NewsSource {
   name: string;

--- a/src/Types/News.ts
+++ b/src/Types/News.ts
@@ -1,0 +1,13 @@
+/** @format */
+
+import type { NewsArticle } from '../Redux/Slices/News/types';
+
+export interface NewsModalBoxProps {
+  onClose: () => void;
+  news: NewsArticle;
+}
+
+export interface NewsCardProps {
+  news: NewsArticle;
+  index: number;
+}


### PR DESCRIPTION
Added logic to delete bookmarked news items by index.

Updated deleteBookmark reducer to filter out the selected item.

Connected delete action to bookmark modal UI.

Now users can remove saved articles from bookmarks with a single click.